### PR TITLE
Add navigation prompts for Frappe repo

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -1,0 +1,15 @@
+# Repository Navigation
+
+This repository contains the core code of the **Frappe Framework**. Use the navigation files listed below to gather context for specific topics when developing a Frappe application.
+
+- [Doctypes](nav_doctypes.md)
+- [APIs](nav_apis.md)
+- [Websites](nav_websites.md)
+- [Permissions](nav_permissions.md)
+- [Fixtures](nav_fixtures.md)
+- [Hooks](nav_hooks.md)
+- [Patches](nav_patches.md)
+- [Webforms](nav_webforms.md)
+- [Scheduled Tasks](nav_scheduled.md)
+
+Each `nav_<topic>.md` file contains prompt templates and directory hints so you can load only the necessary code in context.

--- a/nav_apis.md
+++ b/nav_apis.md
@@ -1,0 +1,10 @@
+# APIs Navigation
+
+Prompt:
+
+```
+Um Endpunkte oder RPC-Methoden zu verstehen, untersuche die Dateien in
+`frappe/api` und `frappe/core/api`. Suche auch nach Funktionen mit dem
+Dekorator `@frappe.whitelist` in den jeweiligen Modulen. Öffne nur die
+relevanten Funktionsdefinitionen, um den Kontext kompakt zu halten.
+```

--- a/nav_doctypes.md
+++ b/nav_doctypes.md
@@ -1,0 +1,12 @@
+# Doctypes Navigation
+
+Verwende diesen Prompt, um Kontext zu DocType-Definitionen zu laden:
+
+```
+Analysiere oder erstelle einen DocType. Suche im Repository nach dem Ordner
+`frappe/**/doctype/<DocType>` und öffne dort die Dateien `<DocType>.json`
+(für Felder) sowie `<DocType>.py` (für Logik). Beispiele liegen unter
+`frappe/core/doctype`, `frappe/desk/doctype`, `frappe/website/doctype` und
+anderen Modulverzeichnissen.
+Fasse nur die relevanten Abschnitte der Dateien prägnant zusammen.
+```

--- a/nav_fixtures.md
+++ b/nav_fixtures.md
@@ -1,0 +1,11 @@
+# Fixtures Navigation
+
+Prompt:
+
+```
+Beispiel- und Testdaten liegen unter `frappe/custom/fixtures` sowie
+`frappe/core/doctype/data_import/fixtures`. Hier findest du JSON- oder
+CSV-Dateien als Vorlage. Eigene Fixtures legst du üblich im App-Verzeichnis
+unter `fixtures` ab. Lade nur die benötigten Dateien, um den Kontext klein
+zu halten.
+```

--- a/nav_hooks.md
+++ b/nav_hooks.md
@@ -1,0 +1,11 @@
+# Hooks Navigation
+
+Prompt:
+
+```
+Einstellungen wie Events, Scheduler oder Erweiterungen findest du in
+`frappe/hooks.py`. In eigenen Apps gibt es ebenfalls eine `hooks.py`.
+Suche hier nach Einträgen wie `doc_events`, `scheduler_events` oder
+`override_whitelisted_methods`. Lade nur die Abschnitte, die für deine
+Aufgabe relevant sind.
+```

--- a/nav_patches.md
+++ b/nav_patches.md
@@ -1,0 +1,11 @@
+# Patches Navigation
+
+Prompt:
+
+```
+Versionsaktualisierungen werden über Dateien in `frappe/patches` und der
+Liste `frappe/patches.txt` gesteuert. Jede Patch-Datei enthält eine
+`execute()`-Funktion. Um eine bestimmte Migration zu prüfen, suche nach dem
+entsprechenden Eintrag in `patches.txt` und öffne dann die zugehörige
+Python-Datei.
+```

--- a/nav_permissions.md
+++ b/nav_permissions.md
@@ -1,0 +1,11 @@
+# Permissions Navigation
+
+Prompt:
+
+```
+Um Berechtigungen zu verstehen, sieh dir `frappe/permissions.py` sowie die
+DocType-spezifischen Funktionen wie `get_permission_query_conditions` oder
+`has_permission` an. Diese befinden sich in den jeweiligen DocType-Modulen.
+Lade nur die relevanten Funktionsabschnitte, um einen kompakten Überblick zu
+bekommen.
+```

--- a/nav_scheduled.md
+++ b/nav_scheduled.md
@@ -1,0 +1,11 @@
+# Scheduled Tasks Navigation
+
+Prompt:
+
+```
+Geplante Jobs werden in `frappe/utils/scheduler.py` und 
+`scheduler_events` in `frappe/hooks.py` definiert. Weitere Modelle findest du
+unter `frappe/core/doctype/scheduled_job_type` und `.../scheduled_job_log`.
+Um einen bestimmten Job zu untersuchen, suche nach seinem Namen in diesen
+Dateien und fasse die relevanten Funktionen kurz zusammen.
+```

--- a/nav_webforms.md
+++ b/nav_webforms.md
@@ -1,0 +1,10 @@
+# Webforms Navigation
+
+Prompt:
+
+```
+Webforms liegen in den Verzeichnissen `frappe/website/doctype/web_form` und
+`frappe/core/web_form`. Dort findest du für jeden Webform Ordner eine
+JSON-Datei mit den Feldern sowie eine Python-Datei für die Logik. Suche nach
+der passenden Webform und lade nur die relevanten Dateien.
+```

--- a/nav_websites.md
+++ b/nav_websites.md
@@ -1,0 +1,10 @@
+# Websites Navigation
+
+Prompt:
+
+```
+Um Website-Funktionen zu bearbeiten, öffne die Seiten unter `frappe/www`
+(HTML und Python). Weitere Module und Templates findest du in `frappe/website`
+sowie unter `templates` und `public` für statische Assets. Lade nur die jeweils
+benötigten Dateien, um den Kontext schlank zu halten.
+```


### PR DESCRIPTION
## Summary
- add a root `nav.md` linking to topic files
- create navigation files with prompt templates:
  - doctypes
  - apis
  - websites
  - permissions
  - fixtures
  - hooks
  - patches
  - webforms
  - scheduled tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f7e0fbb248321a8c86d5a90abf068