### PR TITLE
Update DocType navigation

### DIFF
--- a/nav_doctypes.md
+++ b/nav_doctypes.md
@@ -1,12 +1,36 @@
 # Doctypes Navigation
 
-Verwende diesen Prompt, um Kontext zu DocType-Definitionen zu laden:
+Dieses Dokument bietet einen schnellen Überblick, wo DocType-Definitionen und zugehöriger Code im Repository liegen.
 
+## Verzeichnisse
+DocTypes befinden sich in Unterordnern namens `doctype` in verschiedenen Modulen. Häufig genutzte Pfade sind u. a.:
+
+- `frappe/core/doctype`
+- `frappe/desk/doctype`
+- `frappe/website/doctype`
+- `frappe/email/doctype`
+- `frappe/custom/doctype`
+- `frappe/contacts/doctype`
+- `frappe/automation/doctype`
+- `frappe/social/doctype`
+- `frappe/geo/doctype`
+- `frappe/printing/doctype`
+- `frappe/integrations/doctype`
+- `frappe/workflow/doctype`
+- `frappe/core/form_tour/doctype`
+- `frappe/public/js/frappe/doctype` (Client‑seitige Hilfen)
+
+Die Basisklassen findest du unter `frappe/model/document.py` und `frappe/model/base_document.py`.
+
+## Aufbau eines DocType-Verzeichnisses
+Ein DocType umfasst typischerweise folgende Dateien:
+
+- `<DocType>.json` – Felddefinitionen und Einstellungen
+- `<DocType>.py` – serverseitige Logik
+- optional `<DocType>.js` – clientseitige Logik
+- optionale weitere Ressourcen wie `<DocType>.md`, Test- oder Patch-Verzeichnisse
+
+## Prompt-Vorlage
 ```
-Analysiere oder erstelle einen DocType. Suche im Repository nach dem Ordner
-`frappe/**/doctype/<DocType>` und öffne dort die Dateien `<DocType>.json`
-(für Felder) sowie `<DocType>.py` (für Logik). Beispiele liegen unter
-`frappe/core/doctype`, `frappe/desk/doctype`, `frappe/website/doctype` und
-anderen Modulverzeichnissen.
-Fasse nur die relevanten Abschnitte der Dateien prägnant zusammen.
+Analysiere oder erstelle einen DocType. Suche im Repository nach `frappe/**/doctype/<DocType>` und öffne die genannten Dateien. Fasse anschließend die relevanten Abschnitte prägnant zusammen.
 ```


### PR DESCRIPTION
## Summary
- expand DocType navigation guide with all module paths
- include info about base classes and standard file structure

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686f82aabeb883219db4a6cf33d21351