### PR TITLE
Update fixture navigation

### DIFF
--- a/nav_fixtures.md
+++ b/nav_fixtures.md
@@ -3,9 +3,13 @@
 Prompt:
 
 ```
-Beispiel- und Testdaten liegen unter `frappe/custom/fixtures` sowie
-`frappe/core/doctype/data_import/fixtures`. Hier findest du JSON- oder
-CSV-Dateien als Vorlage. Eigene Fixtures legst du üblich im App-Verzeichnis
-unter `fixtures` ab. Lade nur die benötigten Dateien, um den Kontext klein
-zu halten.
+Beispiel- und Testdaten findest du in
+`frappe/custom/fixtures`, `frappe/core/doctype/data_import/fixtures`
+und `cypress/fixtures` (inklusive Anhänge für E2E-Tests).
+Python-Hilfen zum Import/Export liegen in `frappe/utils/fixtures.py`.
+Tests dazu sind unter `frappe/tests/test_fixture_import.py` und
+`frappe/tests/test_exporter_fixtures.py` zu finden. Der Setup Wizard
+nutzt `frappe/desk/page/setup_wizard/install_fixtures.py`.
+Eigene Fixtures speicherst du im App-Verzeichnis `fixtures`.
+Lade nur die benötigten Dateien, um den Kontext klein zu halten.
 ```


### PR DESCRIPTION
## Summary
- expand fixture navigation info with additional file paths

## Testing
- `pytest -k fixtures` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_686f82d82bf483219ffd965eb9352a10