### PR TITLE
Update navigation for scheduled tasks

### DIFF
--- a/nav_scheduled.md
+++ b/nav_scheduled.md
@@ -3,9 +3,18 @@
 Prompt:
 
 ```
-Geplante Jobs werden in `frappe/utils/scheduler.py` und 
-`scheduler_events` in `frappe/hooks.py` definiert. Weitere Modelle findest du
-unter `frappe/core/doctype/scheduled_job_type` und `.../scheduled_job_log`.
-Um einen bestimmten Job zu untersuchen, suche nach seinem Namen in diesen
-Dateien und fasse die relevanten Funktionen kurz zusammen.
+Geplante Aufgaben laufen über `frappe/utils/scheduler.py`. Dort findest du
+Funktionen wie `enqueue_events` oder `is_scheduler_inactive`.
+Die konkreten Events sind im Dictionary `scheduler_events` in
+`frappe/hooks.py` hinterlegt und werden bei Bedarf als
+`Scheduled Job Type` unter `frappe/core/doctype/scheduled_job_type` erzeugt.
+Protokolle findest du im `Scheduled Job Log` unter
+`frappe/core/doctype/scheduled_job_log`.
+Server Scripts vom Typ „Scheduler Event" erstellen Jobs über
+`frappe/core/doctype/server_script/server_script.py`.
+Der CLI-Einstiegspunkt liegt in `frappe/commands/scheduler.py`.
+Weitere Statusinformationen liefert der `System Health Report` unter
+`frappe/desk/doctype/system_health_report`.
+Um einen bestimmten Job zu untersuchen, suche nach seinem Methodennamen in
+diesen Dateien und lade nur die relevanten Funktionsdefinitionen.
 ```


### PR DESCRIPTION
## Summary
- expand `nav_scheduled.md` with more context about scheduler locations and related modules

## Testing
- `pre-commit run --files nav_scheduled.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f82f565b883218a0c5e703d27b939