### PR TITLE
Add email navigation file

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -4,6 +4,7 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 
 - [Doctypes](nav_doctypes.md)
 - [APIs](nav_apis.md)
+- [Emails](nav_emails.md)
 - [Websites](nav_websites.md)
 - [Permissions](nav_permissions.md)
 - [Fixtures](nav_fixtures.md)

--- a/nav_emails.md
+++ b/nav_emails.md
@@ -1,0 +1,17 @@
+# Emails Navigation
+
+Prompt:
+
+```
+Um das E-Mail-System zu verstehen, sieh dir das Paket `frappe/email` an.
+Wichtige Dateien und Ordner sind:
+- `__init__.py` mit Hilfsfunktionen wie `sendmail_to_system_managers` und RPCs.
+- `email_body.py` für die Erstellung der MIME-Nachrichten.
+- `doctype/` enthält DocTypes wie `email_queue` oder `email_account`, die Versand
+  und Empfang steuern.
+- `assets/` bietet Bilder und weitere Ressourcen für E-Mail-Templates.
+- `email.md` erläutert die Architektur des gesamten Moduls.
+Bei Bedarf findest du in `queue.py`, `receive.py` und `smtp.py` weitere
+Funktionen für das Abrufen und Versenden von Nachrichten. Lade jeweils nur die
+relevanten Funktionsdefinitionen, um den Kontext kompakt zu halten.
+```


### PR DESCRIPTION
## Summary
- add navigation hints for email modules
- link new file in central navigation document

## Testing
- `pre-commit run --files nav.md nav_emails.md` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f84a6743483218d1b87283aa39773