### PR TITLE
Add integrations navigation docs

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -8,6 +8,7 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 - [Permissions](nav_permissions.md)
 - [Fixtures](nav_fixtures.md)
 - [Hooks](nav_hooks.md)
+- [Integrations](nav_integrations.md)
 - [Patches](nav_patches.md)
 - [Webforms](nav_webforms.md)
 - [Scheduled Tasks](nav_scheduled.md)

--- a/nav_integrations.md
+++ b/nav_integrations.md
@@ -1,0 +1,16 @@
+# Integrations Navigation
+
+Prompt:
+
+```
+Die wichtigsten Integrationsmodule liegen unter `frappe/integrations`.
+Schlüsseldateien sind:
+- `__init__.py`
+- `doctype/` mit verschiedenen Integration-DocTypes
+- `frappe_providers/` mit Hilfsfunktionen für FrappeCloud
+- `google_oauth.py` für OAuth-Anbindung an Google
+- `oauth2.py` als generischer OAuth2-Server
+
+Sieh dir bei Fragen zu Integrationen nur die benötigten Module in diesem
+Verzeichnis an, um den Kontext klein zu halten.
+```


### PR DESCRIPTION
## Summary
- document integration modules in new `nav_integrations.md`
- link new navigation file from main `nav.md`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f84b1381883219aa925833fdee806