### PR TITLE
Add printing navigation file

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -9,6 +9,7 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 - [Fixtures](nav_fixtures.md)
 - [Hooks](nav_hooks.md)
 - [Patches](nav_patches.md)
+- [Printing](nav_printing.md)
 - [Webforms](nav_webforms.md)
 - [Scheduled Tasks](nav_scheduled.md)
 

--- a/nav_printing.md
+++ b/nav_printing.md
@@ -1,0 +1,15 @@
+# Printing Navigation
+
+Prompt:
+
+```
+Quellcode zu Druckfunktionen und Print-Formaten liegt im Verzeichnis `frappe/printing`.
+
+- `__init__.py` initialisiert das Modul
+- `doctype/` enthält DocTypes wie `print_format`, `print_settings` oder `letter_head`
+- `form_tour/` liefert geführte Touren zu Druck-Doctypes
+- `page/` umfasst Seiten wie `print` und `print_format_builder`
+- `print_style/` bietet CSS-Themes für Drucklayouts
+
+Suche bei Aufgaben rund um Print-Formate in diesen Ordnern nach den relevanten Dateien und öffne nur die benötigten Ausschnitte.
+```


### PR DESCRIPTION
## Summary
- add nav file for Printing module
- link to the new file in the main navigation index

## Testing
- `pre-commit run --files nav.md nav_printing.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f84bc6b0483218ff3b0fe66b9a9d2