### PR TITLE
Add navigation for workflows

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -11,5 +11,6 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 - [Patches](nav_patches.md)
 - [Webforms](nav_webforms.md)
 - [Scheduled Tasks](nav_scheduled.md)
+- [Workflows](nav_workflows.md)
 
 Each `nav_<topic>.md` file contains prompt templates and directory hints so you can load only the necessary code in context.

--- a/nav_workflows.md
+++ b/nav_workflows.md
@@ -1,0 +1,17 @@
+# Workflows Navigation
+
+Prompt:
+
+```
+Workflows steuern mehrstufige Freigabeprozesse fuer Dokumente.
+Der zugehoerige Code liegt unter `frappe/workflow/doctype`:
+- `workflow` als zentrales Workflow-DocType
+- `workflow_action` und `workflow_action_master` fuer moegliche Aktionen
+- `workflow_action_permitted_role` legt Rollenrechte fest
+- `workflow_document_state` und `workflow_state` beschreiben Zustaende
+- `workflow_transition` definiert die moeglichen Uebergaenge
+Die Oberflaeche zum Erstellen findest du in
+`frappe/workflow/page/workflow_builder`.
+Lade nur die benoetigten Dateien wie `.py`, `.json` oder Tests,
+um den Kontext schlank zu halten.
+```


### PR DESCRIPTION
## Summary
- add nav_workflows.md to describe workflow-related modules
- reference the new navigation file in nav.md

## Testing
- `pre-commit run --files nav.md nav_workflows.md` *(fails: command not found)*
- `pytest -k nothing -s` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_686f84c9bcbc832189b7a6c89ba20897