### PR TITLE
Add CLI commands navigation

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -11,5 +11,6 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 - [Patches](nav_patches.md)
 - [Webforms](nav_webforms.md)
 - [Scheduled Tasks](nav_scheduled.md)
+- [CLI Commands](nav_commands.md)
 
 Each `nav_<topic>.md` file contains prompt templates and directory hints so you can load only the necessary code in context.

--- a/nav_commands.md
+++ b/nav_commands.md
@@ -1,0 +1,17 @@
+# CLI Commands Navigation
+
+Prompt:
+
+```
+Die verschiedenen Kommandozeilenbefehle des Frappe Frameworks befinden sich im Verzeichnis `frappe/commands`.
+Relevante Dateien sind unter anderem:
+- `__init__.py` (Command-Gruppen und gemeinsame Optionen)
+- `gettext.py` (Übersetzungswerkzeuge)
+- `redis_utils.py` (Redis-Hilfen)
+- `scheduler.py` (Scheduler-Steuerung)
+- `site.py` (Site- und Installationsbefehle)
+- `translate.py` (Datenübersetzung)
+- `utils.py` (allgemeine Helferfunktionen)
+
+Öffne nur die nötigen Funktionsdefinitionen oder Click-Kommandos, um den Kontext schlank zu halten.
+```


### PR DESCRIPTION
## Summary
- add new markdown file `nav_commands.md` describing CLI commands directory
- link it from the repository navigation index

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f84d13fd48321ad9a8a515456d7a6