### PR TITLE
Add nav file for search module

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -11,5 +11,6 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 - [Patches](nav_patches.md)
 - [Webforms](nav_webforms.md)
 - [Scheduled Tasks](nav_scheduled.md)
+- [Search](nav_search.md)
 
 Each `nav_<topic>.md` file contains prompt templates and directory hints so you can load only the necessary code in context.

--- a/nav_search.md
+++ b/nav_search.md
@@ -1,0 +1,14 @@
+# Search Navigation
+
+Prompt:
+
+```
+Suche-Funktionen liegen im Modul `frappe/search`.
+Verschaffe dir zuerst einen Überblick in `frappe/search/__init__.py`, dort ist `web_search` als Whitelist-Methode verfügbar.
+
+Die Basisklasse `FullTextSearch` befindet sich in `frappe/search/full_text_search.py`.
+Website-spezifische Suche wird mit `WebsiteSearch` in `frappe/search/website_search.py` umgesetzt.
+Beispiele und Tests findest du in `frappe/search/test_full_text_search.py`.
+
+Öffne nur die relevanten Klassendefinitionen und Methoden, um den Kontext übersichtlich zu halten.
+```


### PR DESCRIPTION
## Summary
- add nav_search.md for search utilities
- link Search navigation from the main nav

## Testing
- `pre-commit run --files nav.md nav_search.md` *(fails: command not found)*
- `pytest frappe/search/test_full_text_search.py -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_686f84f758308321bb9607a1913bc576