### PR TITLE
Improve nav docs, add theme instructions

### DIFF
--- a/nav.md
+++ b/nav.md
@@ -14,6 +14,7 @@ This repository contains the core code of the **Frappe Framework**. Use the navi
 - [Translations](nav_translations.md)
 - [Reports](nav_reports.md)
 - [Printing](nav_printing.md)
+- [Themes](nav_themes.md)
 - [Webforms](nav_webforms.md)
 - [Database](nav_database.md)
 - [Scheduled Tasks](nav_scheduled.md)

--- a/nav_doctypes.md
+++ b/nav_doctypes.md
@@ -30,7 +30,7 @@ Ein DocType umfasst typischerweise folgende Dateien:
 - optional `<DocType>.js` – clientseitige Logik
 - optionale weitere Ressourcen wie `<DocType>.md`, Test- oder Patch-Verzeichnisse
 
-## Prompt-Vorlage
+Prompt:
 ```
 Analysiere oder erstelle einen DocType. Suche im Repository nach `frappe/**/doctype/<DocType>` und öffne die genannten Dateien. Fasse anschließend die relevanten Abschnitte prägnant zusammen.
 ```

--- a/nav_themes.md
+++ b/nav_themes.md
@@ -1,0 +1,9 @@
+# Themes Navigation
+
+Prompt:
+
+```
+Um das Erscheinungsbild anzupassen, sieh dir zuerst die DocType `website_theme` unter `frappe/website/doctype/website_theme` und zugehörige Templates in `frappe/website/website_theme` an. SCSS-Dateien für Website und Desk liegen unter `frappe/public/scss/website` bzw. `frappe/public/scss/desk`. Der Wechsel zwischen hellen und dunklen Themes erfolgt über `frappe/public/js/frappe/ui/theme_switcher.js`.
+
+Eigene Bootstrap-Themes kannst du mit `generate_bootstrap_theme.js` erstellen. Weitere Beispiele findest du in `frappe/templates/includes/website_theme`. Lade nur die benötigten Dateien, um den Kontext schlank zu halten.
+```


### PR DESCRIPTION
## Summary
- add a new `nav_themes.md` with references to theme-related files
- link the new nav doc from `nav.md`
- standardize docstring header in `nav_doctypes.md`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f86cb8de08321bd75102000733470